### PR TITLE
Simplify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import nodePath from 'node:path';
 
-const isPathCwd = path => !nodePath.relative(nodePath.resolve(path), process.cwd());
+const isPathCwd = path => !nodePath.relative(path, process.cwd());
 
 export default isPathCwd;

--- a/test.js
+++ b/test.js
@@ -11,7 +11,9 @@ const reversedCaseCwd = [...cwd].map(
 
 test('main', t => {
 	t.true(isPathCwd(cwd));
+	t.true(isPathCwd(cwd + '/'));
 	t.true(isPathCwd('.'));
+	t.true(isPathCwd('./'));
 	t.false(isPathCwd('foo'));
 	t.false(isPathCwd('/'));
 	t.false(isPathCwd('..'));


### PR DESCRIPTION
After reading how `path.relation` works, we can drop the `path.resolve()` call, because it's already done in `path.relation`

https://github.com/nodejs/node/blob/6710c00e563016728a235d1761189781bda2ccbe/lib/path.js#L545

and

https://github.com/nodejs/node/blob/6710c00e563016728a235d1761189781bda2ccbe/lib/path.js#L1286